### PR TITLE
Support model parallel

### DIFF
--- a/sam.py
+++ b/sam.py
@@ -19,7 +19,7 @@ class SAM(torch.optim.Optimizer):
 
             for p in group["params"]:
                 if p.grad is None: continue
-                e_w = p.grad * scale
+                e_w = p.grad * scale.to(p)
                 p.add_(e_w)  # climb to the local maximum "w + e(w)"
                 self.state[p]["e_w"] = e_w
 
@@ -40,9 +40,10 @@ class SAM(torch.optim.Optimizer):
         raise NotImplementedError("SAM doesn't work like the other optimizers, you should first call `first_step` and the `second_step`; see the documentation for more info.")
 
     def _grad_norm(self):
+        tensor_device=self.param_groups[0]["params"][0]
         norm = torch.norm(
                     torch.stack([
-                        p.grad.norm(p=2)
+                        p.grad.norm(p=2).to(tensor_device)
                         for group in self.param_groups for p in group["params"]
                         if p.grad is not None
                     ]),

--- a/sam.py
+++ b/sam.py
@@ -40,10 +40,10 @@ class SAM(torch.optim.Optimizer):
         raise NotImplementedError("SAM doesn't work like the other optimizers, you should first call `first_step` and the `second_step`; see the documentation for more info.")
 
     def _grad_norm(self):
-        tensor_device=self.param_groups[0]["params"][0]
+        shared_device = self.param_groups[0]["params"][0].device  # put everything on the same device, in case of model parallelism
         norm = torch.norm(
                     torch.stack([
-                        p.grad.norm(p=2).to(tensor_device)
+                        p.grad.norm(p=2).to(shared_device)
                         for group in self.param_groups for p in group["params"]
                         if p.grad is not None
                     ]),


### PR DESCRIPTION
@davda54 Thanks for your working! 
Reason: when the tensor of the group inside the optimizer is not on the same device (such as model parallel, etc.), the error will be reported.

`RuntimeError: All input tensors must be on the same device. Received cuda:0 and cuda:1`

Submit: Only modify three lines of code and look forward to your feedback！:smiley: