### PR TITLE
Fix checkpointing issue #34

### DIFF
--- a/sam.py
+++ b/sam.py
@@ -56,3 +56,7 @@ class SAM(torch.optim.Optimizer):
                     p=2
                )
         return norm
+
+    def load_state_dict(self, state_dict):
+        super().load_state_dict(state_dict)
+        self.base_optimizer.param_groups = self.param_groups


### PR DESCRIPTION
When using load_state_dict to resume from checkpoint, SAM's .state_dict attribute did not point to the base optimizer's .state_dict, and the base optimizer's state_dict was not correctly loaded.
This simple fix should stop this from happening, solving #34.