### PR TITLE
rho argument parameter type

### DIFF
--- a/example/train.py
+++ b/example/train.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     parser.add_argument("--learning_rate", default=0.1, type=float, help="Base learning rate at the start of the training.")
     parser.add_argument("--momentum", default=0.9, type=float, help="SGD Momentum.")
     parser.add_argument("--threads", default=2, type=int, help="Number of CPU threads for dataloaders.")
-    parser.add_argument("--rho", default=2.0, type=int, help="Rho parameter for SAM.")
+    parser.add_argument("--rho", default=2.0, type=float, help="Rho parameter for SAM.")
     parser.add_argument("--weight_decay", default=0.0005, type=float, help="L2 weight decay.")
     parser.add_argument("--width_factor", default=8, type=int, help="How many times wider compared to normal ResNet.")
     args = parser.parse_args()


### PR DESCRIPTION
issue #58  
- fixed rho parameter type error for argument parser in train.py script.
 On branch main
 Your branch is up to date with 'origin/main'.

 Changes to be committed:
	modified:   example/train.py