### PR TITLE
bugfix: update default values using default values of the base optimizer

### DIFF
--- a/sam.py
+++ b/sam.py
@@ -10,6 +10,7 @@ class SAM(torch.optim.Optimizer):
 
         self.base_optimizer = base_optimizer(self.param_groups, **kwargs)
         self.param_groups = self.base_optimizer.param_groups
+        self.defaults.update(self.base_optimizer.defaults)
 
     @torch.no_grad()
     def first_step(self, zero_grad=False):


### PR DESCRIPTION
Signed-off-by: Jimyeong Kim <wlaud1001@snu.ac.kr>

Hi, thank you for great implmentation of SAM optimizer.
I'm graduated student studying deep learning, and interested in research using flat minima.

I came across your implementation while studying and found an minor error related to [add_param_group](https://pytorch.org/docs/stable/generated/torch.optim.Optimizer.add_param_group.html) function.

As you can see in [PyTorch implementation](https://github.com/pytorch/pytorch/blob/df748b60f7bfc0a6b031ad151a0b44f9d68ff52b/torch/optim/optimizer.py#L278), optimizer sets their default values after the param group is added.

However, in your SAM implementation, a problem occurs that the SAM optimizer does not include all the default values of the base optimizer except for the passed arguments, which eventually causes an error.
All passed aruments are set appropriately due to [this code](https://github.com/davda54/sam/blob/295977586de6a6e38f4730adb2ae496fd75f94ec/sam.py#L8). However, it is cumbersome to always pass all the arguments.


For example, in case of SGD,
```
base_optimizer = torch.optim.SGD
optimizer = SAM(list(model.parameters())[:-1], base_optimizer, rho=args.rho, adaptive=args.adaptive, lr=args.learning_rate, momentum=args.momentum, weight_decay=args.weight_decay)
optimizer.add_param_group({'params': list(model.parameters())[-1]})

for i, g in enumerate(optimizer.param_groups):
    print(i+1, g.keys())
```
this results in
```
1 dict_keys(['params', 'rho', 'adaptive', 'lr', 'momentum', 'weight_decay', 'dampening', 'nesterov'])
2 dict_keys(['params', 'rho', 'adaptive', 'lr', 'momentum', 'weight_decay'])
```
You can see that ```momentum``` and ```weight_decay``` are included in the second group without any problem, since those arguemts has been passed and set to default properly.
However, ```damplening``` and ```nesterov``` are only included in the first group, while not in the second group.
They were included in the first group thanks to [this code](https://github.com/davda54/sam/blob/295977586de6a6e38f4730adb2ae496fd75f94ec/sam.py#L12), but not the second group because they weren't set to default, and this is where the error occurs.
![image](https://user-images.githubusercontent.com/28920463/172031327-bdbb5b7f-a553-4cfd-bd45-8d8ace8d9294.png)

So, I suggest modifying the code to update default values with default values of the base optimizer.
```
self.defaults.update(self.base_optimizer.defaults)
```

By adding this one line to init, the above print result is changed to below and the error disappears.
```
1 dict_keys(['params', 'rho', 'adaptive', 'lr', 'momentum', 'weight_decay', 'dampening', 'nesterov'])
2 dict_keys(['params', 'rho', 'adaptive', 'lr', 'momentum', 'weight_decay', 'dampening', 'nesterov'])
```

Thanks again for your great implementation, and your code really helps me a lot.

Best regards,
Jimyeong Kim