### PR TITLE
Torch optimisers expect the step function to run the closure immediately if passed

### DIFF
--- a/sam.py
+++ b/sam.py
@@ -40,10 +40,12 @@ class SAM(torch.optim.Optimizer):
     @torch.no_grad()
     def step(self, closure=None):
         assert closure is not None, "Sharpness Aware Minimization requires closure, but it was not provided"
-        closure = torch.enable_grad()(closure)  # the closure should do a full forward-backward pass
+        with torch.enable_grad():
+            closure()
 
         self.first_step(zero_grad=True)
-        closure()
+        with torch.enable_grad():
+            closure()
         self.second_step()
 
     def _grad_norm(self):


### PR DESCRIPTION
As per title. If the closure is not None, we should assume that the parameter's gradients have not been computed, and immediately run the closure. See, e.g., the step function in [torch.optim.adamw](https://github.com/pytorch/pytorch/blob/eae025b1d75aa17dd20d3037a798f9165779b7e2/torch/optim/adamw.py#L163) as an example of this.

Without this, the library won't work out the box with PyTorch Lightning, and I imagine this is also the source of the problem for #90 with the HF transformers/accelerate libraries.